### PR TITLE
fix: update data loading to work with Astro's static build process

### DIFF
--- a/src/utils/dataLoader.js
+++ b/src/utils/dataLoader.js
@@ -1,6 +1,5 @@
-import fs from 'fs/promises';
+import eventsData from '../data/Eventos_de_la_Comunidad_Flesh_and_Blood_Q1_2025.json';
 
-export const loadEventsData = async (jsonPath) => {
-  const jsonContent = await fs.readFile(jsonPath, 'utf-8');
-  return JSON.parse(jsonContent);
+export const loadEventsData = () => {
+  return eventsData;
 };


### PR DESCRIPTION
### Problem:
The data loading function was using `fs/promises` to read a JSON file during runtime. This caused issues during the static build process as Astro does not support dynamic Node.js functionality in production.

### Solution:
- Replaced the `fs` reading logic with direct import of the JSON file to be bundled during the build process.
- This ensures that the data is included statically and works both in development and production environments.

### Benefits:
- Compatibility with Astro's static build.
- Avoids issues related to dynamic file reading in production.
- Simplifies the data loading process for event data.