### PR TITLE
Enhance event ticket display with tournament info

### DIFF
--- a/src/components/EventTicket.astro
+++ b/src/components/EventTicket.astro
@@ -47,12 +47,19 @@ const hasTournament = !!event.tournamentUrl;
     <span class="month">{monthAbbr}</span>
   </div>
   <div class="event-ticket-content">
-    <div class="event-ticket-header">
-      <h3 class="title">{event.icon} {event.title}</h3>
-      <span class="location-badge">{event.location.spot}</span>
-    </div>
-    {cardName && (
-      <p class="card-name">"{cardName}"</p>
+    {cardName ? (
+      <h3 class="tournament-title">
+        <span class="location-part">{event.location.spot}</span>
+        <span class="separator">:</span>
+        <span class="card-name-part">{cardName}</span>
+        <span class="separator">:</span>
+        <span class="format-part">{event.title} Tournament</span>
+      </h3>
+    ) : (
+      <div class="event-ticket-header">
+        <h3 class="title">{event.icon} {event.title}</h3>
+        <span class="location-badge">{event.location.spot}</span>
+      </div>
     )}
     <div class="event-meta">
       <span class="time">{event.time}</span>

--- a/src/components/EventTicket.astro
+++ b/src/components/EventTicket.astro
@@ -23,10 +23,22 @@ const isEven = index % 2 === 0;
 const layoutClass = isEven ? 'event-ticket--left' : 'event-ticket--right';
 const typeClass = `event-type-${(event.type || 'default').toLowerCase()}`;
 const eventKey = `${event.date}-${event.title}-${event.time}`;
+
+// Extract card name from tournament name (strip date portion)
+// Format: "FAB Chaos Sage Jue 12/02/26 : Brothers in Arms" -> "Brothers in Arms"
+const getCardName = (tournamentName?: string) => {
+  if (!tournamentName) return null;
+  const colonIndex = tournamentName.indexOf(':');
+  if (colonIndex === -1) return null;
+  return tournamentName.slice(colonIndex + 1).trim();
+};
+
+const cardName = getCardName(event.tournamentName);
+const hasTournament = !!event.tournamentUrl;
 ---
 
 <article
-  class={`event-ticket ${layoutClass} ${typeClass}`}
+  class={`event-ticket ${layoutClass} ${typeClass} ${hasTournament ? 'event-ticket--has-tournament' : ''}`}
   data-event-date={event.date}
   data-event-key={eventKey}
 >
@@ -35,21 +47,29 @@ const eventKey = `${event.date}-${event.title}-${event.time}`;
     <span class="month">{monthAbbr}</span>
   </div>
   <div class="event-ticket-content">
-    <h3 class="title">{event.icon} {event.title}</h3>
-    <p class="time">{event.time}</p>
-    <p class="location">{event.location.spot} | {event.location.city}</p>
+    <div class="event-ticket-header">
+      <h3 class="title">{event.icon} {event.title}</h3>
+      <span class="location-badge">{event.location.spot}</span>
+    </div>
+    {cardName && (
+      <p class="card-name">"{cardName}"</p>
+    )}
+    <div class="event-meta">
+      <span class="time">{event.time}</span>
+      <span class="city">{event.location.city}</span>
+    </div>
     <div class="actions">
+      {hasTournament && (
+        <a href={event.tournamentUrl} target="_blank" rel="noopener noreferrer" class="action-link action-link--tournament action-link--primary">
+          🏆 Inscribirse
+        </a>
+      )}
       <a href={icsDataUrl} download={`${event.title.replace(/\s/g, '_')}.ics`} class="action-link">
         📥 iCal
       </a>
       <a href={googleCalUrl} target="_blank" rel="noopener noreferrer" class="action-link">
         📅 Google
       </a>
-      {event.tournamentUrl && (
-        <a href={event.tournamentUrl} target="_blank" rel="noopener noreferrer" class="action-link action-link--tournament">
-          🏆 Torneo
-        </a>
-      )}
     </div>
   </div>
 </article>

--- a/src/components/EventTicket.astro
+++ b/src/components/EventTicket.astro
@@ -49,11 +49,9 @@ const hasTournament = !!event.tournamentUrl;
   <div class="event-ticket-content">
     {cardName ? (
       <h3 class="tournament-title">
-        <span class="location-part">{event.location.spot}</span>
-        <span class="separator">:</span>
         <span class="card-name-part">{cardName}</span>
         <span class="separator">:</span>
-        <span class="format-part">{event.title} Tournament</span>
+        <span class="format-part">{event.icon} {event.title} Tournament</span>
       </h3>
     ) : (
       <div class="event-ticket-header">
@@ -63,7 +61,7 @@ const hasTournament = !!event.tournamentUrl;
     )}
     <div class="event-meta">
       <span class="time">{event.time}</span>
-      <span class="city">{event.location.city}</span>
+      <span class="location-full">{event.location.city}, {event.location.spot}</span>
     </div>
     <div class="actions">
       {hasTournament && (

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -11,6 +11,7 @@ export interface Event {
     location: Location;
     date: string;
     tournamentUrl?: string;
+    tournamentName?: string;
 }
 
 export interface Day {

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1339,8 +1339,9 @@ article ul, article ol {
 
 .event-ticket-content .actions {
     display: flex;
+    justify-content: center;
     gap: 1rem;
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
 }
 
 .event-ticket-content .action-link {
@@ -1383,19 +1384,14 @@ article ul, article ol {
     letter-spacing: 0.5px;
 }
 
-/* Tournament title format: LOCATION : Card Name : Format Tournament */
+/* Tournament title format: Card Name : Format Tournament */
 .tournament-title {
-    font-size: 1rem;
+    font-size: 1.25rem;
     font-weight: 600;
     margin: 0 0 0.5rem 0;
     color: #fff;
     line-height: 1.4;
-}
-
-.tournament-title .location-part {
-    text-transform: uppercase;
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.95);
+    text-align: center;
 }
 
 .tournament-title .separator {
@@ -1405,18 +1401,20 @@ article ul, article ol {
 
 .tournament-title .card-name-part {
     font-style: italic;
+    font-weight: 700;
     color: rgba(255, 215, 0, 0.95);
 }
 
 .tournament-title .format-part {
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.8);
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
 }
 
-/* Event meta - time and city */
+/* Event meta - time and location */
 .event-meta {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 0.75rem;
     margin-bottom: 0.5rem;
     flex-wrap: wrap;
@@ -1433,9 +1431,10 @@ article ul, article ol {
     color: #fff;
 }
 
-.event-meta .city {
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.7);
+.event-meta .location-full {
+    font-size: 1rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.9);
 }
 
 /* Primary action link - prominent tournament button */
@@ -1457,11 +1456,11 @@ article ul, article ol {
 
 /* Event Type Gradient Backgrounds - muted for dark theme */
 .event-type-cc {
-    background: linear-gradient(135deg, #4a5568 0%, #2d3748 100%);
+    background: linear-gradient(135deg, #8b3a3a 0%, #5c2626 100%);
 }
 
 .event-type-sage {
-    background: linear-gradient(135deg, #2f5d50 0%, #234840 100%);
+    background: linear-gradient(135deg, #6878a0 0%, #4a5578 100%);
 }
 
 .event-type-blitz {

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1358,6 +1358,82 @@ article ul, article ol {
     color: #fff;
 }
 
+/* Event Ticket Header - title and location badge */
+.event-ticket-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.event-ticket-header .title {
+    margin: 0;
+}
+
+.location-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 0.2rem 0.6rem;
+    background: rgba(255, 255, 255, 0.9);
+    color: #1a1410;
+    border-radius: 0.25rem;
+    letter-spacing: 0.5px;
+}
+
+/* Card name from tournament */
+.card-name {
+    font-size: 0.9rem;
+    font-style: italic;
+    color: rgba(255, 255, 255, 0.95);
+    margin: 0.25rem 0 0.5rem 0;
+    font-weight: 500;
+}
+
+/* Event meta - time and city */
+.event-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.event-meta .time {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin: 0;
+    padding: 0.25rem 0.75rem;
+    background: rgba(255, 255, 255, 0.25);
+    border-radius: 1rem;
+    color: #fff;
+}
+
+.event-meta .city {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Primary action link - prominent tournament button */
+.action-link--primary {
+    background: rgba(255, 215, 0, 0.25) !important;
+    border: 1px solid rgba(255, 215, 0, 0.5);
+    font-weight: 600;
+}
+
+.action-link--primary:hover {
+    background: rgba(255, 215, 0, 0.4) !important;
+    border-color: rgba(255, 215, 0, 0.7);
+}
+
+/* Events with tournaments get subtle highlight */
+.event-ticket--has-tournament {
+    box-shadow: 0 4px 15px rgba(255, 215, 0, 0.15), 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
 /* Event Type Gradient Backgrounds - muted for dark theme */
 .event-type-cc {
     background: linear-gradient(135deg, #4a5568 0%, #2d3748 100%);

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1383,13 +1383,34 @@ article ul, article ol {
     letter-spacing: 0.5px;
 }
 
-/* Card name from tournament */
-.card-name {
-    font-size: 0.9rem;
-    font-style: italic;
+/* Tournament title format: LOCATION : Card Name : Format Tournament */
+.tournament-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem 0;
+    color: #fff;
+    line-height: 1.4;
+}
+
+.tournament-title .location-part {
+    text-transform: uppercase;
+    font-weight: 700;
     color: rgba(255, 255, 255, 0.95);
-    margin: 0.25rem 0 0.5rem 0;
+}
+
+.tournament-title .separator {
+    margin: 0 0.4rem;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.tournament-title .card-name-part {
+    font-style: italic;
+    color: rgba(255, 215, 0, 0.95);
+}
+
+.tournament-title .format-part {
     font-weight: 500;
+    color: rgba(255, 255, 255, 0.8);
 }
 
 /* Event meta - time and city */

--- a/src/data/Eventos_Comunidad_Q1_2026.json
+++ b/src/data/Eventos_Comunidad_Q1_2026.json
@@ -180,7 +180,8 @@
     "Ciudad": "Cali",
     "Emoji": "🌀",
     "EventType": "Sage",
-    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260212"
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260212",
+    "TournamentName": "FAB Chaos Sage Jue 12/02/26 : Brothers in Arms"
   },
   {
     "Date": "2026-02-14",
@@ -191,7 +192,8 @@
     "Ciudad": "Cali",
     "Emoji": "🏗️",
     "EventType": "CC",
-    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260214"
+    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260214",
+    "TournamentName": "FAB Chaos CC Sáb 14/02/26 : Asking for Trouble"
   },
   {
     "Date": "2026-02-14",
@@ -202,7 +204,8 @@
     "Ciudad": "Palmira",
     "Emoji": "🌀",
     "EventType": "Sage",
-    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260214"
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260214",
+    "TournamentName": "FAB Palmira Sage Sáb 14/02/26 : Arrogant Showboating"
   },
   {
     "Date": "2026-02-19",
@@ -213,7 +216,8 @@
     "Ciudad": "Cali",
     "Emoji": "🏗️",
     "EventType": "CC",
-    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260219"
+    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260219",
+    "TournamentName": "FAB Chaos CC Jue 19/02/26 : Beat of the Ironsong"
   },
   {
     "Date": "2026-02-21",
@@ -224,7 +228,8 @@
     "Ciudad": "Cali",
     "Emoji": "🌀",
     "EventType": "Sage",
-    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260221"
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260221",
+    "TournamentName": "FAB Chaos Sage Sáb 21/02/26 : Cries of Encore"
   },
   {
     "Date": "2026-02-21",
@@ -235,7 +240,8 @@
     "Ciudad": "Palmira",
     "Emoji": "🌀",
     "EventType": "Sage",
-    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260221"
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260221",
+    "TournamentName": "FAB Palmira Sage Sáb 21/02/26 : Attention Grabbers"
   },
   {
     "Date": "2026-02-26",
@@ -246,7 +252,8 @@
     "Ciudad": "Cali",
     "Emoji": "🌀",
     "EventType": "Sage",
-    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260226"
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260226",
+    "TournamentName": "FAB Chaos Sage Jue 26/02/26 : Big Bully"
   },
   {
     "Date": "2026-02-28",
@@ -257,7 +264,8 @@
     "Ciudad": "Cali",
     "Emoji": "🏆",
     "EventType": "LL",
-    "TournamentURL": "https://challonge.com/fabco_chaos_ll_20260228"
+    "TournamentURL": "https://challonge.com/fabco_chaos_ll_20260228",
+    "TournamentName": "FAB Chaos LL Sáb 28/02/26 : Bask in Your Own Greatness"
   },
   {
     "Date": "2026-02-28",
@@ -268,7 +276,8 @@
     "Ciudad": "Palmira",
     "Emoji": "🌀",
     "EventType": "Sage",
-    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260228"
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260228",
+    "TournamentName": "FAB Palmira Sage Sáb 28/02/26 : Cheers!"
   },
   {
     "Date": "2026-03-05",

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -18,7 +18,9 @@ const allEvents = eventsData
         location: { spot: e.Location, city: e.Ciudad },
         date: e.Date,
         dateObj: new Date(e.Date),
-        key: `${e.Date}-${e.Event}-${e.Time}`
+        key: `${e.Date}-${e.Event}-${e.Time}`,
+        tournamentUrl: e.TournamentURL,
+        tournamentName: e.TournamentName,
     }))
     .sort((a, b) => a.dateObj.getTime() - b.dateObj.getTime());
 

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -37,6 +37,7 @@ export const getEventsOfMonth = (eventsData, month) => {
       },
       date: event.Date,
       tournamentUrl: event.TournamentURL,
+      tournamentName: event.TournamentName,
     });
     return acc;
   }, {});
@@ -79,6 +80,7 @@ export const getEventsAsFlatList = (eventsData, month) => {
       location: { spot: event.Location, city: event.Ciudad },
       date: event.Date,
       tournamentUrl: event.TournamentURL,
+      tournamentName: event.TournamentName,
     }));
 };
 


### PR DESCRIPTION
- Add tournamentName field to Event interface
- Display card name from tournament (e.g., "Brothers in Arms")
- Make location more prominent with badge styling
- Make tournament link primary action with gold highlight
- Reorganize ticket layout: header with title+location, card name, meta row
- Add tournament names to February events data
- Events with tournaments get subtle gold shadow highlight