### PR TITLE
Redesign header with prominent logo and create March tournaments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,7 @@ Uses the calendar data defined tournaments and creates them according the templa
 ## Language
 
 All content is in Spanish. Date formatting uses Spanish locale via date-fns.
+
+## Development Rules
+
+- **Temporary files**: Always use the project-local `.tmp/` directory instead of system `/tmp`. This keeps temporary files within the project scope.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-const { fabLogo = "/images/FABLogo.png" } = Astro.props;
+const { fabLogo = "/images/FABLogo.png", hideLogo = false } = Astro.props;
 
 const links = [
 { href: "/", icon: "", text: "Inicio" },
@@ -19,25 +19,25 @@ const links = [
 
 <header class="header">
   <nav class="nav">
-    <div class="mx-auto max-w-12xl px-2 sm:px-2 lg:px-8">
+    <div class="mx-auto px-2 lg:px-4">
       <div class="relative flex items-center justify-between nav-items-container">
-        <div class="absolute inset-y-0 left-4 flex items-center md:hidden">
+        <div class="absolute inset-y-0 left-2 flex items-center md:hidden">
           <button id="menu-toggle" class="text-white md:hidden">
             <i class="fa-solid fa-bars"></i>
           </button>
         </div>
-        <div class="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
-          <div class="flex shrink-0 items-center lg:pl-20">
-            <div class="logo">
-              <a href="/">
-                <img class="h-20 w-auto" src={fabLogo} alt="Logo Flesh and Blood" />
-              </a>
-            </div>
+        {!hideLogo && (
+          <div class="logo">
+            <a href="/">
+              <img class="h-20 w-auto" src={fabLogo} alt="Logo Flesh and Blood" />
+            </a>
           </div>
+        )}
+        <div class="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
         </div>
         <div class="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
           <div class="sm:ml-6 nav-links">
-            <div class="flex space-x-4">
+            <div class="flex space-x-2">
               {links.map(link => {
               const isExternal = /^https?:\/\//.test(link.href);
               return (

--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -2,10 +2,15 @@
 const title = "Bienvenido a FAB Colombia";
 ---
 
-<section class="text-center py-16 px-4 max-w-4xl mx-auto backdrop-blur-md">
+<section class="py-8 px-4 max-w-5xl mx-auto backdrop-blur-md">
 
-  <h4>Comunidad de</h4>
-  <h1 class="text-4xl font-bold mb-6">Flesh and Blood Colombia</h1>
+  <div class="welcome-hero">
+    <img src="/images/FABLogo.png" alt="FAB Colombia" class="welcome-hero-logo" />
+    <div class="welcome-hero-text">
+      <h4>Comunidad de</h4>
+      <h1 class="text-4xl font-bold">Flesh and Blood Colombia</h1>
+    </div>
+  </div>
 
   <div class="welcome-grid">
     <!-- Site Overview -->

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -50,32 +50,33 @@ html[data-theme='wtr'] {
 }    
 
 :root {
-  /* FAB Brand Colors: #91160D (Tamarillo), #765D2F (Old Copper), #FCF0EF (Linen) */
+  /* FAB Brand Colors - softened for better readability */
 
-  --primary-color:        #91160d;  /* FAB Tamarillo red */
-  --primary-light:        #b91e12;
-  --primary-dark:         #6b1008;
+  --primary-color:        #6d2020;  /* Softer, desaturated red */
+  --primary-light:        #8b3030;
+  --primary-dark:         #4a1515;
 
-  --secondary-color:      #765d2f;  /* FAB Old Copper */
-  --secondary-light:      #9a7a42;
-  --secondary-dark:       #5a4522;
+  --secondary-color:      #8a7245;  /* Warmer copper */
+  --secondary-light:      #a8905a;
+  --secondary-dark:       #6b5835;
 
-  --accent-color:         #91160d;  /* FAB red accent */
-  --accent-light:         #c41d10;
-  --accent-dark:          #5c0e08;
+  --accent-color:         #a83030;  /* Accent red - visible but not harsh */
+  --accent-light:         #c44040;
+  --accent-dark:          #7a2020;
 
-  --neutral-color:        #fcf0ef;  /* FAB Linen */
-  --neutral-variant:      #e8d5d3;
-  --neutral-bg:           #f5e8e6;
+  --neutral-color:        #f5ebe9;  /* Slightly warmer linen */
+  --neutral-variant:      #e0d0cc;
+  --neutral-bg:           #f0e5e2;
 
   --base-color:           #2a2320;  /* Dark brown base */
   --base-variant:         #3d3530;
   --base-bg:              #1a1410;
 
-  --text-color:           #fcf0ef;  /* FAB Linen for text */
-  --muted-color:          #a89080;
-  --border-color:         #765d2f;  /* FAB Old Copper */
-  --transparent-veil:     rgba(145, 22, 13, 0.1);
+  --text-color:           #f0e8e5;  /* Warmer, softer white */
+  --text-secondary:       #c8b8b0;  /* Secondary text */
+  --muted-color:          #9a8a80;
+  --border-color:         #5a4a3a;  /* Darker border */
+  --transparent-veil:     rgba(109, 32, 32, 0.1);
 
   /* Light backgrounds - cream/linen tones */
   --bg-light-1: #fcf0ef;
@@ -205,37 +206,54 @@ html[data-theme='highseas-light'] {
 
 body {
     margin: 0;
-    font-family: Roboto, Arial, sans-serif;
+    font-family: 'Inter', Roboto, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
     background-color: var(--bg-dark-1);
-    
-    color:var(--text-color);
-    
+    color: var(--text-color);
     width: 100%;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 .welcome {
     color:var(--text-color);
 }
 
+.header {
+    overflow: visible;
+}
+
 .nav {
     background-color: var(--primary-color);
     color: var(--text-color);
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     position: relative;
     z-index: 100;
+    padding: 0.5rem 0;
+    overflow: visible;
+    min-height: 2.5rem;
+}
+
+.nav-items-container {
+    padding: 0;
+    min-height: auto;
+    overflow: visible;
 }
 
 .nav a {
     color: var(--text-color);
     text-decoration: none;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.375rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.85rem;
+    font-weight: 500;
     transition: background-color 0.2s, color 0.2s;
 }
 
 .nav a:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    color: var(--neutral-color);
+    background-color: rgba(255, 255, 255, 0.15);
+    color: #fff;
 }
 
 .nav-links {
@@ -256,9 +274,68 @@ body {
 }
 
 .logo {
-    background-color: var(--transparent-veil);
-    border-bottom-left-radius: 45%;
-    border-bottom-right-radius: 45%;
+    background-color: var(--primary-color);
+    border-bottom-left-radius: 50%;
+    border-bottom-right-radius: 50%;
+    padding: 0.25rem 0.75rem 0.75rem;
+    line-height: 0;
+    position: absolute;
+    top: 0;
+    left: 1.5rem;
+    z-index: 50;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+@media (min-width: 1024px) {
+    .logo {
+        left: 2rem;
+    }
+}
+
+/* Welcome page hero */
+.welcome-hero {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.welcome-hero-logo {
+    width: 160px;
+    height: auto;
+    filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.4));
+}
+
+.welcome-hero-text {
+    text-align: left;
+}
+
+.welcome-hero-text h4 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1rem;
+    color: var(--muted-color);
+}
+
+.welcome-hero-text h1 {
+    margin: 0;
+    line-height: 1.1;
+}
+
+@media (max-width: 640px) {
+    .welcome-hero {
+        flex-direction: column;
+        text-align: center;
+        gap: 1rem;
+    }
+
+    .welcome-hero-logo {
+        width: 120px;
+    }
+
+    .welcome-hero-text {
+        text-align: center;
+    }
 }
 
 main {

--- a/src/data/Eventos_Comunidad_Q1_2026.json
+++ b/src/data/Eventos_Comunidad_Q1_2026.json
@@ -13,7 +13,7 @@
     "Date": "2026-01-03",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -43,7 +43,7 @@
     "Date": "2026-01-10",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -73,7 +73,7 @@
     "Date": "2026-01-17",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -103,7 +103,7 @@
     "Date": "2026-01-24",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -133,7 +133,7 @@
     "Date": "2026-01-31",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -165,7 +165,7 @@
     "Date": "2026-02-07",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -199,7 +199,7 @@
     "Date": "2026-02-14",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -235,7 +235,7 @@
     "Date": "2026-02-21",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
@@ -271,13 +271,25 @@
     "Date": "2026-02-28",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
     "EventType": "Sage",
     "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260228",
     "TournamentName": "FAB Palmira Sage Sáb 28/02/26 : Cheers!"
+  },
+  {
+    "Date": "2026-03-03",
+    "Day": "Martes",
+    "Event": "Freeplay",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🎮",
+    "EventType": "Freeplay",
+    "TournamentURL": "https://challonge.com/fabco_chaos_freeplay_20260303",
+    "TournamentName": "FAB Chaos Freeplay Mar 03/03/26 : Duty Bound Blitz"
   },
   {
     "Date": "2026-03-05",
@@ -287,7 +299,9 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260305",
+    "TournamentName": "FAB Chaos Sage Jue 05/03/26 : Scuttle Toes"
   },
   {
     "Date": "2026-03-07",
@@ -297,17 +311,33 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🏗️",
-    "EventType": "CC"
+    "EventType": "CC",
+    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260307",
+    "TournamentName": "FAB Chaos CC Sáb 07/03/26 : Blunten"
   },
   {
     "Date": "2026-03-07",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260307",
+    "TournamentName": "FAB Palmira Sage Sáb 07/03/26 : Dyed Silk Sleeves"
+  },
+  {
+    "Date": "2026-03-10",
+    "Day": "Martes",
+    "Event": "Freeplay",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🎮",
+    "EventType": "Freeplay",
+    "TournamentURL": "https://challonge.com/fabco_chaos_freeplay_20260310",
+    "TournamentName": "FAB Chaos Freeplay Mar 10/03/26 : Voltic Veil"
   },
   {
     "Date": "2026-03-10",
@@ -327,7 +357,9 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260312",
+    "TournamentName": "FAB Chaos Sage Jue 12/03/26 : Rainbow Goo Trap"
   },
   {
     "Date": "2026-03-14",
@@ -337,17 +369,33 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🏗️",
-    "EventType": "CC"
+    "EventType": "CC",
+    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260314",
+    "TournamentName": "FAB Chaos CC Sáb 14/03/26 : Double Cross Strap"
   },
   {
     "Date": "2026-03-14",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260314",
+    "TournamentName": "FAB Palmira Sage Sáb 14/03/26 : Verdant Tide"
+  },
+  {
+    "Date": "2026-03-17",
+    "Day": "Martes",
+    "Event": "Freeplay",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🎮",
+    "EventType": "Freeplay",
+    "TournamentURL": "https://challonge.com/fabco_chaos_freeplay_20260317",
+    "TournamentName": "FAB Chaos Freeplay Mar 17/03/26 : Helm of Safe Haven"
   },
   {
     "Date": "2026-03-17",
@@ -367,7 +415,9 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🏗️",
-    "EventType": "CC"
+    "EventType": "CC",
+    "TournamentURL": "https://challonge.com/fabco_chaos_cc_20260319",
+    "TournamentName": "FAB Chaos CC Jue 19/03/26 : Valahai Riven"
   },
   {
     "Date": "2026-03-21",
@@ -377,17 +427,33 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260321",
+    "TournamentName": "FAB Chaos Sage Sáb 21/03/26 : Stormweaver's Aegis"
   },
   {
     "Date": "2026-03-21",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260321",
+    "TournamentName": "FAB Palmira Sage Sáb 21/03/26 : Feign Vengeance"
+  },
+  {
+    "Date": "2026-03-24",
+    "Day": "Martes",
+    "Event": "Freeplay",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🎮",
+    "EventType": "Freeplay",
+    "TournamentURL": "https://challonge.com/fabco_chaos_freeplay_20260324",
+    "TournamentName": "FAB Chaos Freeplay Mar 24/03/26 : Channel Galcia's Cradle"
   },
   {
     "Date": "2026-03-24",
@@ -407,7 +473,9 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_chaos_sage_20260326",
+    "TournamentName": "FAB Chaos Sage Jue 26/03/26 : Shield Beater"
   },
   {
     "Date": "2026-03-28",
@@ -417,26 +485,32 @@
     "Location": "Chaos Store",
     "Ciudad": "Cali",
     "Emoji": "🏆",
-    "EventType": "LL"
+    "EventType": "LL",
+    "TournamentURL": "https://challonge.com/fabco_chaos_ll_20260328",
+    "TournamentName": "FAB Chaos LL Sáb 28/03/26 : Oldhim"
   },
   {
     "Date": "2026-03-28",
     "Day": "Sábado",
     "Event": "Silver Age",
-    "Time": "3 PM",
+    "Time": "2 PM",
     "Location": "Palmira",
     "Ciudad": "Palmira",
     "Emoji": "🌀",
-    "EventType": "Sage"
+    "EventType": "Sage",
+    "TournamentURL": "https://challonge.com/fabco_palmira_sage_20260328",
+    "TournamentName": "FAB Palmira Sage Sáb 28/03/26 : Predatory Plating"
   },
   {
     "Date": "2026-03-31",
     "Day": "Martes",
-    "Event": "Free Play",
+    "Event": "Freeplay",
     "Time": "5 PM",
     "Location": "Chaos Store",
     "Ciudad": "Cali",
-    "Emoji": "🃏",
-    "EventType": "FreePlay"
+    "Emoji": "🎮",
+    "EventType": "Freeplay",
+    "TournamentURL": "https://challonge.com/fabco_chaos_freeplay_20260331",
+    "TournamentName": "FAB Chaos Freeplay Mar 31/03/26 : Stormwind Sheath"
   }
 ]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,8 @@
 import '../css/base.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+
+const { hideLogo = false } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -14,10 +16,10 @@ import Footer from '../components/Footer.astro';
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="icon" type="image/svg+xml" href="/public/favicon.svg" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Winky+Rough:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Winky+Rough:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
   </head>
   <body>
-    <Header/>
+    <Header hideLogo={hideLogo} />
     <main class="container mx-auto px-4 mt-4 py-4 rounded-lg">
       <slot />
     </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,6 @@ const year = "2025";
 const months = getMonths(eventsData);
 ---
 
-<Layout>
+<Layout hideLogo={true}>
     <Welcome />
 </Layout>

--- a/tools/challonge/create_tournament.py
+++ b/tools/challonge/create_tournament.py
@@ -308,17 +308,28 @@ def create_tournament_payload(event, templates, cards_data=None):
     except ValueError:
         starts_at = date.replace(hour=17, minute=0).isoformat()  # Default 5 PM
 
-    # Build description with ranking links based on location
+    # Build description with ranking links based on location (HTML format)
+    # Skip rankings for event types with no_rankings flag (e.g., Freeplay)
     description = merged.get('description', '')
     rankings = templates.get('rankings', {})
     location_rankings = location_config.get('rankings', ['season', 'year'])  # Default to Chaos Store rankings
+    no_rankings = merged.get('no_rankings', False)
 
-    if rankings and location_rankings:
-        ranking_links = "\n\nRankings FABCO:\n"
+    if rankings and location_rankings and not no_rankings:
+        ranking_links = '\n\n<p><strong>📊 Rankings:</strong></p>\n<ul>\n'
         for ranking_key in location_rankings:
             if ranking_key in rankings:
-                ranking_links += f"- {rankings[ranking_key]['name']}: {rankings[ranking_key]['url']}\n"
+                name = rankings[ranking_key]['name']
+                url = rankings[ranking_key]['url']
+                ranking_links += f'<li><a href="{url}">{name}</a></li>\n'
+        ranking_links += '</ul>'
         description = description + ranking_links
+
+    # Build ranking_ids from location config
+    ranking_ids = []
+    for ranking_key in location_rankings:
+        if ranking_key in rankings and 'id' in rankings[ranking_key]:
+            ranking_ids.append(rankings[ranking_key]['id'])
 
     # Build payload in JSON:API format
     attributes = {
@@ -329,8 +340,13 @@ def create_tournament_payload(event, templates, cards_data=None):
         'description': description,
         'private': merged.get('private', False),
         'quick_advance': merged.get('quick_advance', True),
-        'starts_at': starts_at
+        'starts_at': starts_at,
+        'group_stage_enabled': False,  # Single stage tournament
     }
+
+    # Add ranking_ids if available
+    if ranking_ids:
+        attributes['ranking_ids'] = ranking_ids
 
     # Add optional nested options
     for opt_key in ['notifications', 'match_options', 'registration_options',

--- a/tools/challonge/templates.json
+++ b/tools/challonge/templates.json
@@ -21,7 +21,7 @@
     "game_name": "Flesh and Blood",
     "private": false,
     "quick_advance": true,
-    "description": "Torneo de Flesh and Blood organizado por FABCO Colombia\n\nRankings:\n- Ranking de Temporada: https://challonge.com/communities/fabco/rankings?id=2002\n- Ranking Anual: https://challonge.com/communities/fabco/rankings?id=2589\n\nPremiación: Según participantes.\nLista de baneo y legalidad: https://fabtcg.com/en/resources/rules-and-policy-center/card-legality-policy\nReglas detalladas del juego: https://fabtcg.com/en/resources/rules-and-policy-center/comprehensive-rules/\nReglas detalladas sobre el torneo: https://fabtcg.com/en/resources/rules-and-policy-center/tournament-rules-and-policy/",
+    "description": "🎴 Torneo de Flesh and Blood\n📍 Organizado por FABCO Colombia\n🌐 https://fabtcgcolombia.club\n\n📋 RECURSOS\n• Legalidad: https://fabtcg.com/resources/rules-and-policy-center/card-legality-policy\n• Reglas: https://fabtcg.com/resources/rules-and-policy-center/comprehensive-rules\n• Torneos: https://fabtcg.com/resources/rules-and-policy-center/tournament-rules-and-policy\n\n🏆 Premiación según participantes",
     "notifications": {
       "upon_matches_open": true,
       "upon_tournament_ends": true
@@ -49,30 +49,42 @@
   "event_types": {
     "CC": {
       "name_prefix": "FABCO CC",
-      "description": "Torneo Classic Constructed - Flesh and Blood\nInventario total de 80 cartas no incluido el heroe, el deck de juego debe ser de minimo 60 cartas.\n Tiempo: Cada ronda tiene un tiempo permitido de 55 minutos.",
+      "description": "<h2>⚔️ CLASSIC CONSTRUCTED</h2>\n\n<p>El formato competitivo principal de Flesh and Blood. Construye un deck de 60+ cartas de tu inventario de 80 y demuestra tu dominio estratégico.</p>\n\n<p>Classic Constructed es donde los mejores jugadores del mundo compiten en el Pro Tour y World Championship. Cada decisión cuenta en este formato de alto nivel táctico.</p>\n\n<p>📦 <strong>Deck:</strong> 60+ cartas (inventario 80)<br>\n⏱️ <strong>Tiempo por ronda:</strong> 55 minutos</p>\n\n<p><strong>🔗 Recursos:</strong></p>\n<ul>\n<li><a href=\"https://fabtcg.com/resources/rules-and-policy-center/formats/classic-constructed\">Reglas Classic Constructed</a></li>\n<li><a href=\"https://fabtcgcolombia.club/formatos\">Formatos FABCO</a></li>\n</ul>",
       "tournament_type": "swiss"
     },
     "Sage": {
       "name_prefix": "FABCO Silver Age",
-      "description": "Torneo Silver Age - Flesh and Blood\nInventario total de 55 cartas no incluido el heroe, el deck de juego debe ser de 40 cartas exactas.\n Tiempo: Cada ronda tiene un tiempo permitido de 35 minutos.",
+      "description": "<h2>🌀 SILVER AGE</h2>\n\n<p>Una forma completamente nueva de jugar Flesh and Blood usando solo cartas comunes, raras y básicas. Con los icónicos héroes jóvenes de FAB, las partidas son rápidas, divertidas y accesibles para todos.</p>\n\n<p>Desde partidas casuales en tu tienda local hasta la competencia de alto nivel del World Tour, Silver Age es la forma definitiva para que <strong>TODOS</strong> disfruten de Flesh and Blood.</p>\n\n<p>📦 <strong>Deck:</strong> 40 cartas exactas (inventario 55)<br>\n⏱️ <strong>Tiempo por ronda:</strong> 35 minutos</p>\n\n<p><strong>🔗 Recursos:</strong></p>\n<ul>\n<li><a href=\"https://fabtcg.com/articles/silver-age\">Sobre Silver Age</a></li>\n<li><a href=\"https://fabtcgcolombia.club/formatos\">Formatos FABCO</a></li>\n</ul>",
       "tournament_type": "swiss"
     },
     "LL": {
       "name_prefix": "FABCO Living Legend",
-      "description": "Torneo Living Legend - Flesh and Blood\nInventario total de 80 cartas no incluido el heroe, el deck de juego debe ser de minimo 60 cartas.\n Tiempo: Cada ronda tiene un tiempo permitido de 55 minutos.",
+      "description": "<h2>🏆 LIVING LEGEND</h2>\n\n<p>El formato eterno donde los héroes que alcanzaron el estatus de Leyenda Viviente regresan a la batalla. Usa cualquier carta de la historia de FAB con los héroes más icónicos del juego.</p>\n\n<p>Living Legend celebra la historia del juego, permitiendo revivir las estrategias clásicas y los héroes legendarios que definieron épocas.</p>\n\n<p>📦 <strong>Deck:</strong> 60+ cartas (inventario 80)<br>\n⏱️ <strong>Tiempo por ronda:</strong> 55 minutos</p>\n\n<p><strong>🔗 Recursos:</strong></p>\n<ul>\n<li><a href=\"https://fabtcg.com/resources/rules-and-policy-center/formats/living-legend\">Reglas Living Legend</a></li>\n<li><a href=\"https://fabtcgcolombia.club/formatos\">Formatos FABCO</a></li>\n</ul>",
       "tournament_type": "swiss"
     },
     "Blitz": {
       "name_prefix": "FABCO Blitz",
-      "description": "Torneo Blitz - Flesh and Blood\nInventario total de 55 cartas no incluido el heroe, el deck de juego debe ser de 40 cartas exactas.\n Tiempo: Cada ronda tiene un tiempo permitido de 35 minutos.",
+      "description": "<h2>⚡ BLITZ</h2>\n\n<p>Partidas rápidas e intensas perfectas para jugadores nuevos y veteranos. El formato ideal para aprender Flesh and Blood y disfrutar partidas dinámicas.</p>\n\n<p>Con héroes jóvenes y decks compactos, Blitz ofrece acción concentrada donde cada carta cuenta. ¡Perfecto para eventos rápidos!</p>\n\n<p>📦 <strong>Deck:</strong> 40 cartas exactas (inventario 55)<br>\n⏱️ <strong>Tiempo por ronda:</strong> 35 minutos</p>\n\n<p><strong>🔗 Recursos:</strong></p>\n<ul>\n<li><a href=\"https://fabtcg.com/resources/rules-and-policy-center/formats/blitz\">Reglas Blitz</a></li>\n<li><a href=\"https://fabtcgcolombia.club/formatos\">Formatos FABCO</a></li>\n</ul>",
       "tournament_type": "swiss"
     },
     "Draft": {
       "name_prefix": "FABCO Sellados y Draft",
-      "description": "Torneo Sellados y Draft - Flesh and Blood\nSegún las reglas del formato",
+      "description": "<h2>🎲 DRAFT / SELLADO</h2>\n\n<p>Construye tu deck a partir de sobres en tiempo real. Pon a prueba tu capacidad de evaluación de cartas y adaptabilidad.</p>\n\n<p>El formato limitado nivela el campo de juego - no importa tu colección, todos comienzan igual. ¡Cada torneo es una experiencia única!</p>\n\n<p>📦 <strong>Deck:</strong> Según reglas de formato limitado<br>\n⏱️ <strong>Tiempo por ronda:</strong> 35 minutos</p>\n\n<p><strong>🔗 Recursos:</strong></p>\n<ul>\n<li><a href=\"https://fabtcg.com/resources/rules-and-policy-center/formats/limited\">Reglas Limitado</a></li>\n<li><a href=\"https://fabtcgcolombia.club/formatos\">Formatos FABCO</a></li>\n</ul>",
       "tournament_type": "swiss",
       "registration_options": {
         "signup_cap": 16
+      }
+    },
+    "Freeplay": {
+      "name_prefix": "FABCO Freeplay",
+      "description": "<h2>🎮 FREEPLAY</h2>\n\n<p>Sesión abierta de juego libre. Ven a practicar, conocer otros jugadores y disfrutar partidas casuales en cualquier formato.</p>\n\n<p>No hay formato específico - trae el deck que quieras y encuentra oponentes para jugar. Perfecto para probar nuevas estrategias, enseñar a nuevos jugadores o simplemente pasar un buen rato.</p>\n\n<p>🎯 <strong>Objetivo:</strong> Matchmaking y registro de participación<br>\n📊 <strong>Rankings:</strong> No aplica<br>\n🃏 <strong>Formato:</strong> Libre</p>\n\n<p><strong>🔗 Recursos:</strong></p>\n<ul>\n<li><a href=\"https://fabtcgcolombia.club/formatos\">Formatos FABCO</a></li>\n<li><a href=\"https://fabtcgcolombia.club/calendar\">Calendario de eventos</a></li>\n</ul>",
+      "tournament_type": "swiss",
+      "no_rankings": true,
+      "registration_options": {
+        "signup_cap": 24
+      },
+      "swiss_options": {
+        "rounds": 3
       }
     }
   },
@@ -85,7 +97,8 @@
     "Palmira": {
       "suffix": "Palmira",
       "short_name": "Palmira",
-      "rankings": ["palmira"]
+      "rankings": ["season", "palmira"],
+      "default_time": "2 PM"
     }
   }
 }


### PR DESCRIPTION
Header improvements:
- Logo now extends below header using absolute positioning
- Red background on logo container as header extension
- Softer red color palette (#6d2020) for better readability
- Inter font added for improved legibility
- Compact nav with reduced padding

Landing page:
- Logo displayed to the left of title in hero section
- Header logo hidden on landing to avoid duplication

March tournaments:
- Created all March 2026 tournaments in Challonge
- Added Freeplay event type (no rankings, casual format)
- Updated calendar with tournament URLs and names
- Palmira events use 2 PM time

Challonge tools:
- Added Freeplay template with no_rankings flag
- HTML formatting for tournament descriptions
- Updated create_tournament.py for new event types