### PR TITLE
Fix text contrast in Code of Conduct boxes for light themes

### DIFF
--- a/src/pages/codigo-de-conducta.astro
+++ b/src/pages/codigo-de-conducta.astro
@@ -438,12 +438,14 @@ const referencias = [
     }
 
     .no-interviene-label {
-        color: var(--muted-color);
+        color: var(--text-color);
         margin-top: 1rem;
+        opacity: 0.9;
     }
 
     .no-interviene-list li {
-        color: var(--muted-color);
+        color: var(--text-color);
+        opacity: 0.9;
     }
 
     .excepcion {
@@ -452,6 +454,7 @@ const referencias = [
         padding: 0.75rem 1rem;
         margin-top: 1rem;
         font-size: 0.95rem;
+        color: var(--text-color);
     }
 
     .enfasis {
@@ -460,6 +463,7 @@ const referencias = [
         padding: 0.75rem 1rem;
         margin-top: 1rem;
         font-weight: 500;
+        color: var(--text-color);
     }
 
     /* Conductas */
@@ -469,10 +473,15 @@ const referencias = [
         padding: 1.25rem;
         margin-bottom: 1rem;
         border-left: 4px solid #4a9d4a;
+        color: var(--text-color);
     }
 
     .conductas-esperadas h3 {
         color: #6abf6a;
+    }
+
+    .conductas-esperadas li {
+        color: var(--text-color);
     }
 
     .conductas-esperadas li::marker {
@@ -484,10 +493,15 @@ const referencias = [
         border-radius: 0.75rem;
         padding: 1.25rem;
         border-left: 4px solid #c45c5c;
+        color: var(--text-color);
     }
 
     .conductas-no-aceptadas h3 {
         color: #e07070;
+    }
+
+    .conductas-no-aceptadas li {
+        color: var(--text-color);
     }
 
     .conductas-no-aceptadas li::marker {
@@ -512,10 +526,15 @@ const referencias = [
         border-radius: 0.75rem;
         padding: 1.25rem;
         border-top: 3px solid #d4a84b;
+        color: var(--text-color);
     }
 
     .faltas-leves h3 {
         color: #e8c36b;
+    }
+
+    .faltas-leves li {
+        color: var(--text-color);
     }
 
     .faltas-leves li::marker {
@@ -527,10 +546,15 @@ const referencias = [
         border-radius: 0.75rem;
         padding: 1.25rem;
         border-top: 3px solid #c45c5c;
+        color: var(--text-color);
     }
 
     .faltas-graves h3 {
         color: #e07070;
+    }
+
+    .faltas-graves li {
+        color: var(--text-color);
     }
 
     .faltas-graves li::marker {
@@ -547,11 +571,13 @@ const referencias = [
         background: var(--bg-dark-1);
         border-radius: 0.75rem;
         padding: 1.25rem 1.25rem 1.25rem 2.5rem;
+        color: var(--text-color);
     }
 
     .medidas-lista li {
         margin-bottom: 0.75rem;
         padding-left: 0.5rem;
+        color: var(--text-color);
     }
 
     .medidas-lista li:last-child {
@@ -565,6 +591,7 @@ const referencias = [
         margin-top: 1rem;
         font-size: 0.95rem;
         border-left: 3px solid var(--secondary-color);
+        color: var(--text-color);
     }
 
     /* Procedimiento */
@@ -574,14 +601,20 @@ const referencias = [
         padding: 1rem 1.25rem;
         margin-top: 1rem;
         border-left: 3px solid #d4a84b;
+        color: var(--text-color);
     }
 
     .excepcion-box p {
         margin-bottom: 0.5rem;
+        color: var(--text-color);
     }
 
     .excepcion-box ul {
         margin-bottom: 0;
+    }
+
+    .excepcion-box li {
+        color: var(--text-color);
     }
 
     /* Autoridad */
@@ -590,6 +623,7 @@ const referencias = [
         border-radius: 0.5rem;
         padding: 0.75rem 1rem;
         font-style: italic;
+        color: var(--text-color);
     }
 
     /* Límites */
@@ -607,6 +641,7 @@ const referencias = [
         padding: 0.75rem 1rem;
         margin-top: 0.5rem;
         font-size: 0.95rem;
+        color: var(--text-color);
     }
 
     /* Referencias */
@@ -615,6 +650,7 @@ const referencias = [
         border-radius: 1rem;
         padding: 1.5rem;
         margin-top: 0.5rem;
+        color: var(--text-color);
     }
 
     .conduct-references h2 {
@@ -624,9 +660,10 @@ const referencias = [
     }
 
     .conduct-references p {
-        color: var(--muted-color);
+        color: var(--text-color);
         margin: 0 0 1rem 0;
         font-size: 0.95rem;
+        opacity: 0.9;
     }
 
     .conduct-references ul {
@@ -636,6 +673,7 @@ const referencias = [
 
     .conduct-references li {
         margin-bottom: 0.5rem;
+        color: var(--text-color);
     }
 
     .conduct-references a {


### PR DESCRIPTION
## Summary
- Fix poor text contrast in nested boxes (like "Alcance y Aplicación") when using light themes
- Replace `--muted-color` with `--text-color` for all content inside `--bg-dark-1` background boxes
- Add explicit `color: var(--text-color)` to ensure readability across all themes
- Affected sections: marco items, excepcion boxes, enfasis boxes, conductas, faltas, medidas, procedimiento, autoridad, limites, and referencias

## Test plan
- [ ] View `/codigo-de-conducta` in default (dark) theme - text should remain readable
- [ ] Switch to `high-seas-light` theme - verify all text boxes have proper contrast
- [ ] Check nested boxes specifically (excepcion, enfasis, medidas-lista, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)