### PR TITLE
Fix text contrast in Code of Conduct for light theme

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -982,7 +982,6 @@ main {
 
 /* Legacy article styles - keep for non-blog articles (exclude event tickets) */
 article:not(.blog-post):not(.event-ticket) {
-    background: var(--bg-light-1);
     color: var(--base-color);
     line-height: 1.6;
 }

--- a/src/pages/codigo-de-conducta.astro
+++ b/src/pages/codigo-de-conducta.astro
@@ -427,6 +427,7 @@ const referencias = [
         border-radius: 0.75rem;
         padding: 1.25rem;
         margin-bottom: 1rem;
+        color: var(--base-color);
     }
 
     .marco-item:last-child {


### PR DESCRIPTION
## Summary
- Add `color: var(--base-color)` to `.marco-item` for better text contrast in the highseas-light theme
- Remove `background: var(--bg-light-1)` from legacy article styles to prevent white background override

## Test plan
- [ ] View `/codigo-de-conducta` in highseas-light theme
- [ ] Verify "Alcance y Aplicación" and other marco-item boxes have readable text with proper background

🤖 Generated with [Claude Code](https://claude.com/claude-code)