### PR TITLE
Add guide for introducing new FAB players

### DIFF
--- a/src/content/posts/guia-introducir-jugadores.md
+++ b/src/content/posts/guia-introducir-jugadores.md
@@ -1,0 +1,762 @@
+---
+title: "Introduciendo Jugadores que Permanecen"
+author: "FAB Colombia"
+description: "Guía interna para jugadores y organizadores de FAB Colombia sobre cómo introducir nuevos jugadores de forma sostenible."
+publishDate: 2026-05-24
+---
+
+# Introduciendo Jugadores que Permanecen
+
+Guía interna para jugadores y organizadores de FAB Colombia.
+
+Esta guía está dirigida a jugadores establecidos que quieren ayudar a crecer la comunidad de manera sostenible.
+
+El objetivo no es simplemente enseñar reglas o lograr que alguien juegue una vez.
+
+El objetivo es ayudar a que más personas:
+
+- vuelvan
+- encuentren algo que disfruten dentro del juego
+- desarrollen interés real
+- se integren progresivamente al ecosistema de FAB
+- lleguen a jugar de forma constante
+
+Una demo exitosa no es la que explica más reglas. Es la que deja al jugador con ganas de otra partida.
+
+## Objetivo del documento
+
+Esta guía existe para ayudar a jugadores establecidos a introducir nuevos jugadores de una forma más efectiva.
+
+No busca imponer un único método. Busca dar una base común para que las primeras experiencias sean mejores y para que más personas puedan sostenerse en el juego.
+
+Cuando alguien nuevo llega a Flesh and Blood, normalmente está tratando de entender varias cosas al mismo tiempo:
+
+- qué está pasando en la mesa
+- si el juego le gusta
+- si la comunidad le resulta cómoda
+- si el costo parece manejable
+- si hay un camino claro para seguir
+- si vale la pena volver
+
+Por eso, la primera experiencia no debe tratarse solo como una explicación de reglas.
+
+Debe tratarse como una experiencia completa.
+
+La persona debe jugar, preguntar, mirar cartas, entender el ambiente y salir con un siguiente paso claro.
+
+## Lo más importante: identificar qué le interesa a la persona
+
+No todos los jugadores llegan a Flesh and Blood buscando lo mismo.
+
+Algunas personas se interesan primero por los héroes. Quieren saber quiénes son, cómo se ven, qué hacen y qué estilo tienen.
+
+Otras se interesan por las clases. Les atrae la idea de jugar Guardian, Warrior, Ninja, Runeblade, Mechanologist u otra identidad mecánica.
+
+Otras conectan primero por el arte, la colección, los sobres, las cartas raras o la estética general del juego.
+
+Otras llegan directamente por el competitivo. Quieren saber cuál es el formato principal, cómo son los torneos, qué decks ganan y cómo se mejora rápido.
+
+Otras quieren entender mecánicas. Preguntan por recursos, arsenal, reacciones, cadenas de combate, daño, tempo y decisiones.
+
+El error más común es asumir que lo que más le gusta al jugador veterano es lo que debe gustarle al jugador nuevo.
+
+No siempre es así.
+
+Si una persona se emociona por el arte, no hay que forzarle una conversación de meta desde el primer día.
+
+Si una persona pregunta por torneos, no hay que tratarla como si solo necesitara una demo lenta.
+
+Si una persona mira héroes y clases, hay que usar eso como entrada natural al juego.
+
+La tarea del jugador establecido es observar primero y enseñar después.
+
+Preguntas útiles:
+
+- ¿Qué héroe le llamó la atención?
+- ¿Qué carta miró más tiempo?
+- ¿Preguntó por torneos o por colección?
+- ¿Le interesó más ganar, entender o explorar?
+- ¿Disfrutó atacar, bloquear, combinar cartas o mirar opciones?
+- ¿Se frustró con demasiada información?
+- ¿Pidió más profundidad o necesitó menos velocidad?
+
+La primera sesión debe adaptarse a esas señales.
+
+## Qué hace que un jugador permanezca
+
+La mayoría de jugadores no deja FAB porque el juego sea difícil.
+
+Normalmente se pierden por otras razones:
+
+- reciben demasiada información demasiado rápido
+- sienten que no entienden qué hacer después
+- no conectan con ningún héroe
+- no encuentran una ruta clara para conseguir deck
+- se sienten demasiado presionados
+- no logran integrarse socialmente
+- pierden varias partidas sin entender por qué
+- no saben cuándo volver a jugar
+
+Una buena primera experiencia normalmente tiene estas características:
+
+- la persona juega, no solo escucha
+- entiende el objetivo básico
+- toma algunas decisiones reales
+- recibe ayuda sin sentirse corregida todo el tiempo
+- encuentra algo que le interesa
+- sabe cuál es el siguiente evento
+- sabe a quién preguntar después
+
+La meta no es que salga entendiendo FAB completo.
+
+La meta es que salga pensando:
+
+> quiero volver a probar esto
+
+## Cómo preparar una primera sesión
+
+Antes de enseñar, hay que preparar la experiencia.
+
+Una mala demo muchas veces empieza antes de la primera carta: mesa desordenada, deck demasiado complejo, demasiadas cartas visibles, tokens faltantes, explicaciones largas y cero claridad sobre qué se va a hacer.
+
+Para una primera sesión conviene preparar:
+
+- dos decks listos
+- tokens necesarios
+- dados o contadores
+- mesa limpia
+- héroes con planes claros
+- una explicación inicial corta
+- tiempo suficiente para jugar sin correr
+
+Si hay varios jugadores nuevos, no intente atender a todos de la misma forma.
+
+Mejor organizar pequeñas mesas o parejas, con un jugador establecido acompañando cada partida cuando sea posible.
+
+Para una demo de 2 personas:
+
+- explicar objetivo básico
+- jugar una partida abierta
+- pausar solo cuando sea necesario
+- cerrar con preguntas y siguiente paso
+
+Para una demo de 3 o 4 personas:
+
+- evitar explicaciones largas al grupo
+- hacer que jueguen rápido
+- rotar atención
+- resolver dudas puntuales
+- mantener la energía de la mesa
+
+La primera sesión no debe sentirse como una clase.
+
+Debe sentirse como una noche de juego donde alguien nuevo puede participar sin estar perdido.
+
+## Cómo enseñar por capas
+
+No es necesario explicar todo el juego en la primera sesión.
+
+El orden recomendado es:
+
+### Primera capa: flujo básico
+
+- cada jugador tiene un héroe
+- el objetivo es reducir la vida del oponente
+- las cartas se usan para atacar, defender, pagar costos o generar efectos
+- al final del turno se roba hasta completar mano
+- el arsenal permite guardar una carta
+
+### Segunda capa: decisiones principales
+
+- cuándo atacar
+- cuándo bloquear
+- cuándo guardar cartas
+- cuándo usar arsenal
+- cuándo aceptar daño
+
+### Tercera capa: estructura del combate
+
+- cadena de combate
+- ataques
+- defensa
+- reacciones
+- resolución de daño
+
+### Cuarta capa: juego real
+
+- tempo
+- eficiencia de mano
+- lectura del oponente
+- turnos grandes
+- planificación
+- matchups
+
+No todos necesitan llegar a la cuarta capa el primer día.
+
+Algunos jugadores la van a pedir rápido. Otros necesitan varias sesiones en las primeras capas.
+
+Eso no es un problema.
+
+La guía debe permitir que el jugador avance sin sentirse empujado más rápido de lo que disfruta.
+
+## Reducir complejidad sin deformar el juego
+
+Reducir complejidad no significa enseñar un juego falso.
+
+Significa escoger una experiencia donde el jugador pueda ver el corazón de FAB sin ahogarse en detalles.
+
+Conviene evitar al inicio:
+
+- demasiados triggers
+- muchas reacciones escondidas
+- decks que dependen de una secuencia larga
+- héroes que requieren conocer muchas excepciones
+- partidas donde el jugador nuevo no entiende por qué perdió
+- demasiadas cartas distintas en mesa al mismo tiempo
+
+Conviene usar:
+
+- héroes con plan claro
+- ataques fáciles de leer
+- decisiones visibles
+- manos que permitan bloquear y atacar
+- partidas donde el jugador vea progreso
+
+La persona debe sentir que está jugando FAB real, no una versión infantil del juego.
+
+Pero también debe poder entender qué está pasando.
+
+## CC y Silver Age
+
+Classic Constructed es el formato principal de Flesh and Blood.
+
+Es donde se experimenta el juego en toda su profundidad y donde el ecosistema competitivo tiene mayor peso.
+
+Silver Age es un formato viable, completo y competitivo. Funciona muy bien para entrada porque reduce costo y cantidad de cartas disponibles, pero mantiene decisiones reales y estructura competitiva.
+
+La forma correcta de presentarlo es:
+
+> Silver Age ayuda a entrar.  
+> CC muestra el juego completo.
+
+No se debe presentar Silver Age como formato casual, ni como una versión menor del juego.
+
+Tampoco se debe empujar a todos hacia CC el primer día.
+
+La progresión sana puede ser:
+
+- primera demo
+- partidas guiadas
+- Silver Age
+- Armories
+- CC cuando el jugador esté listo para explorar el juego completo
+
+El punto no es forzar una ruta única.
+
+El punto es que el jugador entienda que hay camino.
+
+## Silver Age como herramienta de entrada
+
+Los productos Silver Age fueron diseñados por LSS como una entrada accesible al juego organizado.
+
+Los decks vienen listos para jugar y están pensados para:
+
+- aprender el flujo real de FAB
+- jugar eventos locales
+- explorar clases y héroes distintos
+- entrar al competitivo sin construir un deck desde cero
+
+Todos los decks usan únicamente cartas common, rare y basic, manteniendo el formato accesible y fácil de expandir progresivamente.
+
+Cada deck incluye:
+
+- deck preconstruido de 55 cartas
+- héroe y básicas
+- booster pack
+- experiencia lista para jugar desde la caja
+
+Para FAB Colombia, conviene mantener varios decks Silver Age armados permanentemente para:
+
+- demos rápidas
+- onboarding
+- préstamo
+- eventos introductorios
+- sesiones guiadas
+- Barracas
+
+Idealmente deben cubrir:
+
+- héroes distintos
+- complejidad variada
+- estilos distintos
+- decks siempre sleeved y listos para jugar
+
+La barrera de entrada más importante normalmente no es aprender reglas.
+
+Es lograr sentarse a jugar una primera partida real sin fricción.
+
+## Cómo escoger héroes y decks introductorios
+
+El héroe correcto para una primera experiencia no siempre es el héroe más fuerte, más barato o más fácil para el jugador veterano.
+
+El héroe correcto es el que ayuda al jugador nuevo a entender algo del juego y conectar con la experiencia.
+
+Para escoger bien, mire primero qué le interesa a la persona.
+
+Si le interesa la estética, muestre héroes visualmente fuertes y deje que escoja entre varias opciones.
+
+Si le interesa competir, muestre héroes con planes claros y explíquele qué se juega en Silver Age y qué se ve en CC.
+
+Si le interesan las mecánicas, muestre diferencias simples entre clases: atacar fuerte, bloquear bien, hacer varias acciones, usar arma, preparar turnos grandes.
+
+Si le interesa la colección, muestre cómo se construye un deck, qué cartas son importantes y cómo puede empezar sin comprar todo de una vez.
+
+Si viene de otros TCGs, pregúntele qué estilo jugaba antes. Eso ayuda mucho.
+
+Ejemplos de estilos que puede identificar:
+
+- agresión rápida
+- control de ritmo
+- ataques grandes
+- uso constante de arma
+- combos
+- juego defensivo
+- juego técnico
+- estética de clase
+- colección y arte
+
+No es necesario encontrar el héroe perfecto el primer día.
+
+Sí es importante evitar que la primera experiencia sea con un deck que solo funciona si el jugador ya entiende muchas capas del juego.
+
+Para primeras partidas conviene usar decks que:
+
+- tengan un plan fácil de explicar
+- permitan atacar y defender con claridad
+- no dependan de muchas excepciones
+- tengan pocas cartas que requieran explicación larga
+- permitan que el jugador tome decisiones reales
+- muestren la identidad del héroe
+
+Evite al inicio:
+
+- decks que dependen de secuencias largas
+- decks que solo funcionan con mucha práctica previa
+- héroes que esconden demasiado la razón por la cual ganan
+- listas llenas de interacciones raras
+- decks que castigan demasiado cada error
+
+Una buena frase para guiar la selección es:
+
+> Este deck debe permitir que el jugador entienda por qué ganó, por qué perdió y qué podría intentar diferente en la siguiente partida.
+
+## Cómo introducir competitivo sin espantar
+
+FAB Colombia tiene dirección competitiva, pero eso no significa que cada jugador nuevo deba sentirse evaluado desde el primer día.
+
+El competitivo debe presentarse como camino, no como barrera.
+
+Una persona nueva debe entender tres cosas:
+
+- puede empezar sin saber todo
+- perder al inicio es normal
+- hay un camino claro para mejorar
+
+No hace falta hablar de meta, listas óptimas, resultados internacionales o matchups complejos durante la primera sesión, salvo que la persona pregunte por eso directamente.
+
+Para muchos jugadores, una explicación simple es suficiente:
+
+> Jugamos semanalmente. Primero puede probar, luego jugar Silver Age, después entrar a Armories y con el tiempo explorar CC.
+
+Eso normaliza la competencia sin meter presión.
+
+Una de las fortalezas más importantes de FAB Colombia es la regularidad.
+
+La comunidad no depende de eventos improvisados o invitaciones sueltas. Hay horarios consistentes, eventos recurrentes y un calendario que ayuda a todos a saber cuándo se juega, qué formato toca y cuál puede ser el siguiente paso.
+
+Para un jugador nuevo, esa consistencia reduce mucha incertidumbre.
+
+No tiene que adivinar cuándo volver.
+
+Puede mirar el calendario, escoger una fecha concreta y entender que hay una comunidad activa esperándolo.
+
+Los Armories deben presentarse como eventos oficiales locales donde se juega con seriedad, pero donde también se puede aprender. No son una final mundial, pero tampoco son una reunión sin estructura.
+
+GEM debe explicarse de forma simple:
+
+> Para eventos oficiales se usa una cuenta GEM. Cuando llegue el momento, le ayudamos a crearla.
+
+No lo ponga como trámite inicial si la persona apenas está probando el juego.
+
+El orden sano normalmente es:
+
+- probar el juego
+- repetir algunas partidas
+- escoger héroe o estilo
+- jugar Silver Age
+- participar en eventos locales
+- crear GEM para eventos oficiales
+- explorar CC cuando tenga más claridad
+
+El competitivo no debe esconderse.
+
+Pero tampoco debe usarse para impresionar.
+
+La mejor forma de mostrarlo es con hechos:
+
+- horarios claros
+- torneos regulares
+- jugadores practicando
+- decks prestados
+- conversación de partidas
+- revisión de errores
+- invitación al siguiente evento
+
+## Cómo acompañar derrotas consecutivas
+
+FAB puede ser frustrante al inicio, especialmente cuando una persona pierde varias partidas seguidas.
+
+Eso no debe minimizarse.
+
+Perder muchas veces sin entender qué ocurrió puede hacer que el jugador sienta que el juego no es para él, que está muy atrás o que necesita gastar demasiado para poder participar.
+
+Cuando eso pase, conviene separar tres cosas:
+
+- el resultado de la partida
+- la calidad de las decisiones que tomó
+- lo que puede aprender para la siguiente sesión
+
+No toda derrota significa que jugó mal.
+
+A veces está aprendiendo un héroe nuevo, enfrentando una clase desconocida, usando un deck prestado o jugando contra alguien con mucha más experiencia.
+
+La recomendación no debe ser simplemente:
+
+> siga jugando hasta que gane
+
+Es mejor ayudarle a encontrar progreso concreto:
+
+- bloqueó mejor que la vez anterior
+- identificó cuándo guardar arsenal
+- entendió una línea de ataque
+- reconoció una amenaza antes de que resolviera
+- hizo una pregunta más precisa
+- eligió mejor qué cartas pagar y cuáles conservar
+
+Eso convierte la derrota en información.
+
+También ayuda explicar cómo funcionan los torneos.
+
+Por su propia naturaleza, un torneo tiende a emparejar a los jugadores con personas que tienen resultados similares durante el evento. Después de las primeras rondas, es normal que alguien que perdió algunas partidas empiece a jugar contra oponentes más cercanos a su nivel o con una experiencia similar ese día.
+
+Por eso participar importa aunque el resultado final no sea bueno.
+
+Un torneo no es solo una tabla de posiciones.
+
+Es una experiencia completa:
+
+- jugar varias rondas seguidas
+- conocer más héroes y clases
+- practicar manejo de tiempo
+- aprender a recuperarse después de perder
+- conversar con oponentes
+- ver cómo otros construyen y juegan sus decks
+- entender mejor el ambiente competitivo local
+
+Para un jugador nuevo, terminar un torneo ya puede ser una victoria importante.
+
+El objetivo inicial no siempre debe ser ganar el evento.
+
+Puede ser:
+
+- jugar todas las rondas
+- entender mejor su deck
+- identificar una decisión que quiere mejorar
+- conocer dos o tres jugadores nuevos
+- salir con ganas de volver al siguiente evento
+
+## Cómo manejar distintos tipos de jugadores
+
+No todos los jugadores necesitan la misma primera experiencia.
+
+### Jugador competitivo inmediato
+
+Puede querer saber:
+
+- qué formato importa más
+- qué decks son fuertes
+- cuánto cuesta entrar
+- cómo practicar
+- cuándo hay torneo
+
+Con ese jugador, puede avanzar más rápido. Probablemente tolere más información, pero igual conviene no saturarlo con detalles que todavía no puede aplicar.
+
+### Jugador visual o de colección
+
+Puede querer ver:
+
+- héroes
+- arte
+- cartas bonitas
+- rarezas
+- productos
+- identidad de clases
+
+Con ese jugador, empiece por mostrarle el mundo del juego. Luego conecte eso con mecánicas simples.
+
+### Jugador social
+
+Puede necesitar:
+
+- sentirse bien recibido
+- entender quiénes juegan
+- saber cuándo volver
+- tener una mesa cómoda
+- no sentirse juzgado
+
+Con ese jugador, la experiencia de comunidad pesa tanto como la partida.
+
+### Jugador analítico
+
+Puede preguntar mucho:
+
+- por qué bloquear
+- por qué guardar arsenal
+- por qué usar una carta para pagar otra
+- cómo se decide un turno
+- cómo se mide una mano buena
+
+Con ese jugador, explique más, pero en contexto. Es mejor mostrar una decisión real que dar una clase completa.
+
+### Jugador tímido
+
+Puede no preguntar casi nada.
+
+Eso no significa que no esté interesado.
+
+Observe si:
+
+- mira cartas con atención
+- acepta otra partida
+- vuelve a revisar héroes
+- escucha explicaciones
+- responde mejor cuando se le pregunta directamente
+
+Con ese jugador, no llene el silencio con demasiada información. Dé espacio, pregunte poco y permita que juegue.
+
+## Errores comunes del jugador veterano
+
+El jugador veterano normalmente quiere ayudar, pero puede cometer errores que dañan la experiencia.
+
+Los más comunes son:
+
+- intentar demostrar cuánto sabe
+- explicar demasiadas reglas antes de jugar
+- comparar todo con otros TCGs
+- hablar demasiado del meta
+- corregir cada decisión
+- ganar demasiado rápido sin explicar nada
+- usar jerga interna
+- asumir que todos quieren competir igual
+- hablar de precios antes de que exista interés real
+- recomendar decks demasiado complejos
+- presentar Silver Age como si fuera un formato menor
+- empujar CC demasiado temprano
+- no dar un siguiente paso concreto
+
+Una buena introducción requiere contener el entusiasmo propio.
+
+No se trata de mostrar todo lo que FAB puede ser.
+
+Se trata de mostrar lo suficiente para que la persona quiera descubrir más.
+
+## Cómo cerrar una sesión introductoria
+
+El cierre es importante.
+
+No deje que la sesión termine simplemente con:
+
+> bueno, ahí está el juego
+
+El jugador debe salir con una idea clara de qué hacer después.
+
+Al cerrar, puede preguntar:
+
+- ¿qué héroe le llamó más la atención?
+- ¿qué parte le gustó más?
+- ¿quiere probar otra clase la próxima vez?
+- ¿le gustaría venir a Silver Age?
+- ¿quiere que le ayudemos a armar algo básico?
+
+Luego dé un siguiente paso concreto:
+
+- invitarlo al próximo jueves
+- pasarle el link de empezar
+- agregarlo al grupo
+- prestarle un deck para la siguiente sesión
+- recomendarle mirar héroes
+- mostrarle el calendario
+- explicarle cuándo tendría sentido crear GEM
+
+La continuidad no ocurre sola.
+
+Hay que hacerla fácil.
+
+## Construir continuidad
+
+Muchas veces el momento más importante no es la primera partida.
+
+Es lo que ocurre después.
+
+Ayuda mucho:
+
+- decir claramente cuándo se vuelve a jugar
+- usar el calendario como referencia común
+- recomendar un siguiente paso concreto
+- ayudar a conseguir deck
+- conectarlo con jugadores compatibles
+- recomendar formatos adecuados
+- invitarlo a eventos específicos
+- normalizar que perder varias partidas seguidas puede ser parte del proceso
+- ayudar a convertir derrotas en objetivos pequeños para la siguiente sesión
+
+La mayoría de jugadores permanece porque logra integrarse progresivamente al ecosistema.
+
+El juego no se sostiene solo porque tenga profundidad.
+
+Se sostiene porque la persona encuentra experiencias repetidas que valen la pena.
+
+Por eso la regularidad de FAB Colombia importa tanto.
+
+Tener horarios estables y un calendario vivo convierte el interés inicial en hábito. La persona no solo descubre que el juego existe; descubre cuándo puede volver, con quién puede jugar y cómo seguir avanzando.
+
+## Checklist rápido para una demo
+
+Antes de empezar:
+
+- llevar decks listos
+- llevar tokens
+- llevar dados o contadores
+- tener sleeves en buen estado
+- tener mesa limpia
+- revisar que ambos decks funcionen bien
+- escoger héroes claros
+- preparar una explicación de menos de dos minutos
+
+Durante la partida:
+
+- explicar objetivo básico
+- jugar abierto
+- verbalizar decisiones
+- responder preguntas en contexto
+- evitar corregir cada error
+- evitar jugar demasiado rápido
+- observar qué le interesa a la persona
+- ajustar ritmo según reacción
+
+Después de la partida:
+
+- preguntar qué le gustó
+- preguntar qué le confundió
+- recomendar siguiente paso
+- invitar al próximo evento
+- compartir link de la web
+- conectarlo con el grupo
+- ofrecer ayuda para escoger héroe o deck
+
+## Herramientas útiles
+
+### Material oficial
+
+Legend Story Studios tiene una página oficial para aprender a jugar Flesh and Blood. Incluye tutorial interactivo, reglas rápidas, Ira Welcome Deck y otros recursos para jugadores nuevos.
+
+- Learn to Play: https://fabtcg.com/learn-to-play/
+
+También existe el Ira Welcome Deck Print & Play en español.
+
+- Ira Welcome Deck Print & Play Español: https://dhhim4ltzu1pj.cloudfront.net/media/documents/IRA_Welcome_Deck_Print__Play_-_Spanish.pdf
+
+### Herramientas digitales
+
+- Talishar
+- Felt Table
+- Goldfish Tool de FAB Colombia
+
+### Juego organizado
+
+- Armories
+- GEM
+- Calendario de FAB Colombia como guía principal de fechas, formatos y siguientes oportunidades para jugar
+- Chaos Store
+
+## Cierre
+
+Introducir jugadores nuevos no es solamente enseñar reglas.
+
+Es leer a la persona, ajustar el ritmo, mostrarle una parte del juego que pueda disfrutar y darle una razón concreta para volver.
+
+Una comunidad crece mejor cuando cada jugador establecido puede ayudar a otro jugador a encontrar su lugar en el juego.
+
+## Anexo A: Silver Age Chapters y decks preconstruidos
+
+Este anexo resume los héroes disponibles por Chapter y cuándo puede ser útil cada grupo de decks.
+
+### Chapter 1
+
+Pensado como introducción amplia a clases fundamentales del juego.
+
+Héroes:
+- Bravo
+- Dash
+- Iyslander
+- Kayo
+- Viserai
+
+Estos decks funcionan muy bien para:
+- aprender fundamentos
+- identificar estilos de juego
+- primeras demos
+- eventos internos
+- jugadores provenientes de otros TCGs
+
+### Chapter 2
+
+Introduce héroes con identidades más marcadas y estilos más distintos entre sí.
+
+Héroes:
+- Arakni
+- Azalea
+- Dorinthea
+- Enigma
+- Fai
+
+Estos decks funcionan bien para:
+- jugadores que ya jugaron algunas partidas
+- personas interesadas en clases específicas
+- introducir matchups más variados
+- transición hacia juego más competitivo
+
+### Chapter 3
+
+Chapter 3 amplía aún más la variedad de estilos disponibles y ayuda a introducir héroes y clases menos tradicionales.
+
+Héroes:
+- Lyath Goldmane
+- Gravy Bones
+- Boltyn
+- Briar
+- Blaze
+
+Estos decks permiten introducir:
+- estrategias más especializadas
+- daño arcano
+- sinergias más visibles
+- estilos híbridos
+- identidades de clase más fuertes
+
+No todos los Chapter 3 son ideales como primera demo absoluta.
+
+Algunos funcionan mejor para:
+- jugadores que ya entienden flujo básico
+- personas que ya identificaron qué estilos disfrutan
+- transición hacia partidas más profundas


### PR DESCRIPTION
## Summary
- Add a new Spanish guide for introducing and retaining new Flesh and Blood players
- Cover demo structure, Silver Age onboarding, regular calendar-driven play, handling repeated losses, and tournament participation
- Move technical Silver Age chapter/deck details into an annex-style section

## Verification
- yarn build