### PR TITLE
[codex] Add Skirmish post and extend calendar

### DIFF
--- a/src/components/EventTicket.astro
+++ b/src/components/EventTicket.astro
@@ -1,5 +1,5 @@
 ---
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { es } from 'date-fns/locale';
 import type { Event } from './interfaces';
 import { generateICS, getGoogleCalendarLink } from './interfaces';
@@ -11,7 +11,7 @@ interface Props {
 
 const { event, index } = Astro.props;
 
-const eventDate = new Date(event.date);
+const eventDate = parseISO(event.date);
 const dayNumber = format(eventDate, 'd');
 const monthAbbr = format(eventDate, 'MMM', { locale: es }).toUpperCase();
 
@@ -79,6 +79,12 @@ const formatUrl = event.type ? formatUrls[event.type] : null;
       <span class="time">{event.time}</span>
       <span class="location-full">{event.location.city}, {event.location.spot}</span>
     </div>
+    {(event.registrationFee || event.description) && (
+      <div class="event-details">
+        {event.registrationFee && <span class="registration-fee">Inscripción: {event.registrationFee}</span>}
+        {event.description && <p>{event.description}</p>}
+      </div>
+    )}
     <div class="actions">
       {hasTournament && (
         <a href={event.tournamentUrl} target="_blank" rel="noopener noreferrer" class="action-link action-link--tournament action-link--primary">

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -12,6 +12,8 @@ export interface Event {
     date: string;
     tournamentUrl?: string;
     tournamentName?: string;
+    registrationFee?: string;
+    description?: string;
 }
 
 export interface Day {
@@ -29,30 +31,38 @@ function estimateEndTime(dtStart: string): string {
   const minute = parseInt(dtStart.slice(11, 13), 10);
   const second = parseInt(dtStart.slice(13, 15), 10);
 
-  const startDate = new Date(Date.UTC(year, month, day, hour, minute, second));
-  const endDate = new Date(startDate.getTime() + 3 * 60 * 60 * 1000); // Add 3 hours
+  const endDate = new Date(year, month, day, hour, minute, second);
+  endDate.setHours(endDate.getHours() + 3);
 
   const pad = (n: number) => String(n).padStart(2, '0');
   return (
-    endDate.getUTCFullYear().toString() +
-    pad(endDate.getUTCMonth() + 1) +
-    pad(endDate.getUTCDate()) + 'T' +
-    pad(endDate.getUTCHours()) +
-    pad(endDate.getUTCMinutes()) +
-    pad(endDate.getUTCSeconds()) + 'Z'
+    endDate.getFullYear().toString() +
+    pad(endDate.getMonth() + 1) +
+    pad(endDate.getDate()) + 'T' +
+    pad(endDate.getHours()) +
+    pad(endDate.getMinutes()) +
+    pad(endDate.getSeconds())
   );
 }
 
-function formatDateTimeICS(date, time) {
+function formatDateTimeICS(date: string, time: string): string {
   // Example input: date = '2025-05-03', time = '3 PM'
   const [hourStr, modifier] = time.split(' ');
   const hour = parseInt(hourStr, 10) + (modifier === 'PM' && hourStr !== '12' ? 12 : 0);
-  return date.replace(/-/g, '') + 'T' + String(hour).padStart(2, '0') + '0000Z'; // e.g. 20250503T150000Z
+  return date.replace(/-/g, '') + 'T' + String(hour).padStart(2, '0') + '0000'; // e.g. 20250503T150000
 }
 
-export function generateICS(event) {
+function getEventDescription(event: Event): string {
+  return [
+    event.description,
+    event.registrationFee ? `Inscripción: ${event.registrationFee}` : null,
+  ].filter(Boolean).join('\\n') || 'Evento de Flesh and Blood en CHAOS Hobby Store.';
+}
+
+export function generateICS(event: Event) {
   const dtStart = formatDateTimeICS(event.date, event.time);
   const dtEnd = estimateEndTime(dtStart); // add 2 hours for example
+  const description = getEventDescription(event);
 
   return `BEGIN:VCALENDAR
 VERSION:2.0
@@ -64,13 +74,14 @@ DTSTART:${dtStart}
 DTEND:${dtEnd}
 SUMMARY:${event.title}
 LOCATION:${event.location.spot}, ${event.location.city}
-DESCRIPTION:Evento de Flesh and Blood en Chaos Store.
+DESCRIPTION:${description}
 END:VEVENT
 END:VCALENDAR`;
 }
-export function getGoogleCalendarLink(event) {
+export function getGoogleCalendarLink(event: Event) {
   const start = formatDateTimeICS(event.date, event.time);
   const end = estimateEndTime(start);
+  const details = getEventDescription(event);
 
-  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${start}/${end}&details=${encodeURIComponent('Flesh and Blood - Chaos Store')}&location=${encodeURIComponent(event.location.spot + ', ' + event.location.city)}&sf=true&output=xml`;
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${start}/${end}&ctz=America%2FBogota&details=${encodeURIComponent(details)}&location=${encodeURIComponent(event.location.spot + ', ' + event.location.city)}&sf=true&output=xml`;
 }

--- a/src/content/posts/skirmish-2026.md
+++ b/src/content/posts/skirmish-2026.md
@@ -1,0 +1,123 @@
+---
+title: "El primer Skirmish de FAB Colombia en 2026"
+author: "Carlos Perilla"
+description: "Una invitación abierta a jugadores nuevos, activos e inactivos para participar en el siguiente paso competitivo de FAB Colombia en CHAOS Hobby Store."
+publishDate: 2026-07-04
+---
+
+Hay momentos en los que una comunidad empieza a medir su avance de una forma distinta. No solo por cuántas personas llegan a jugar una tarde, sino por la consistencia, por los torneos acumulados, por la mejora de sus jugadores y por la posibilidad de recibir eventos oficiales.
+
+Ese es el punto en el que estamos hoy con FAB Colombia.
+
+Después de varios años de trabajo, de enseñar el juego, prestar mazos, organizar mesas, hacer torneos, viajar a eventos internacionales y mantener una agenda constante, CHAOS Hobby Store recibió la invitación para organizar un evento de nivel Skirmish. Para nosotros no es solo un torneo más. Es una señal de que la comunidad ya tiene una base real.
+
+## Skirmish Season 15 - Silver Age
+
+- **Fecha:** Sábado 8 de agosto de 2026
+- **Hora:** 10:00 a. m.
+- **Lugar:** CHAOS Hobby Store
+- **Inscripción:** $80.000 COP
+
+## Video del anuncio
+
+[Ver el video en YouTube](https://www.youtube.com/watch?v=jpDePozDU04)
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/jpDePozDU04"
+  title="Skirmish Season 15 en Colombia"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen>
+</iframe>
+
+## Por qué existe FAB Colombia
+
+FAB Colombia nació porque queríamos algo más que sentarnos a jugar cartas de vez en cuando.
+
+Muchos veníamos de otros juegos y formatos donde la experiencia podía ser divertida, pero no siempre premiaba el esfuerzo de mejorar. En Flesh and Blood encontramos algo distinto: un juego donde cada decisión importa, donde el margen de mejora es visible y donde perder también puede ser parte de construir nivel.
+
+Al comienzo la comunidad creció de una forma muy sencilla: sentándonos a jugar. Prestando mazos. Explicando líneas básicas. Invitando jugadores uno por uno. Luego vinieron los torneos, las jornadas de práctica, los drafts, las conversaciones de estrategia, los viajes y la necesidad de organizar mejor todo lo que estábamos construyendo.
+
+Con el tiempo entendimos que no bastaba con tener jugadores. Necesitábamos continuidad.
+
+Por eso FAB Colombia ha insistido tanto en tener calendario, estructura, formatos claros y espacios donde un jugador nuevo pueda entrar sin sentirse perdido, pero también donde un jugador competitivo encuentre exigencia real.
+
+## Un evento que representa más que premios
+
+El Skirmish trae premiación oficial y reconocimiento, pero su valor principal para nosotros está en lo que representa.
+
+Representa que la comunidad ha sido constante.
+
+Representa que CHAOS Hobby Store ha sido un punto de encuentro importante para el juego.
+
+Representa que ya no estamos hablando solo de "algún día tendremos eventos oficiales", sino de un paso concreto hacia una escena más grande.
+
+Y representa también una oportunidad: si respondemos bien como comunidad, este tipo de eventos puede abrir la puerta a más soporte, más visibilidad y mejores oportunidades para jugadores de Colombia.
+
+## Silver Age como puerta de entrada competitiva
+
+El formato elegido es Silver Age, y eso es importante.
+
+Silver Age permite jugar con una barrera de entrada mucho más baja, usando cartas comunes y raras. Eso hace que el evento sea más accesible sin perder lo que hace fuerte a Flesh and Blood: la toma de decisiones, la preparación, el conocimiento del héroe y la capacidad de adaptarse durante la partida.
+
+No es un formato donde el dinero de la lista define todo. Ayuda tener una buena construcción, por supuesto, pero el jugador sigue siendo el centro.
+
+Eso lo vuelve ideal para este momento de FAB Colombia. Queremos que jugadores nuevos, jugadores que han estado inactivos y jugadores competitivos se sienten en la misma comunidad con un objetivo claro: jugar más y jugar mejor.
+
+## Lo que ya hemos construido
+
+El año pasado cerramos con una comunidad mucho más madura de lo que muchos imaginan.
+
+Registramos decenas de torneos, cientos de partidas, evolución de jugadores, podios, resultados y una historia competitiva que ya se puede mirar con datos. No es solo la sensación de que "la gente está jugando más". Lo estamos viendo en la práctica.
+
+También empezamos a ver resultados afuera.
+
+Jugadores de la comunidad han competido en eventos internacionales en Brasil y México, con resultados importantes. Eso no pasa por accidente. Un jugador que llega lejos en un torneo grande no llega solo: detrás hay una comunidad que le exige, que le prueba listas, que lo obliga a mejorar y que le da contexto para tomar mejores decisiones.
+
+Ese es uno de los mayores logros de FAB Colombia: estamos formando jugadores que pueden sentarse en mesas exigentes fuera del país y competir.
+
+## La invitación
+
+Este Skirmish es para todos.
+
+Para quienes juegan cada semana.
+
+Para quienes compraron cartas y todavía no se han animado a volver.
+
+Para quienes se bajaron del juego un tiempo.
+
+Para quienes quieren probar Flesh and Blood por primera vez, pero no saben por dónde empezar.
+
+Para quienes quieren jugar Silver Age.
+
+Para quienes quieren prepararse para Classic Constructed.
+
+Y para quienes entienden que una comunidad competitiva no se construye solo con los mejores jugadores, sino con personas que llegan, juegan, aprenden, vuelven y ayudan a que otros también entren.
+
+En FAB Colombia tenemos espacios para eso. Tenemos la Mesa Inicial, tenemos calendario, tenemos jugadores dispuestos a enseñar, tenemos torneos y tenemos una casa en CHAOS Hobby Store donde la comunidad se reúne con regularidad.
+
+## Lo que sigue
+
+Este Skirmish no es el final del camino. Es el siguiente escalón.
+
+La ambición es que Colombia tenga una escena más fuerte, más visible y más conectada. Que podamos invitar jugadores de otras ciudades. Que Medellín, Bogotá, Cali y otras comunidades encuentren puntos de contacto. Que eventualmente podamos aspirar a eventos más grandes, con mayor participación y mayor reconocimiento.
+
+Pero eso no se logra solo con intención.
+
+Se logra asistiendo.
+
+Se logra jugando.
+
+Se logra trayendo un amigo.
+
+Se logra ayudando a un jugador nuevo a entender su primer turno.
+
+Se logra preparando una lista, perdiendo una partida, revisando qué pasó y volviendo a intentarlo.
+
+Ese ha sido el espíritu de FAB Colombia desde el comienzo: competir de forma seria, pero sana. Mejorar sin volvernos tóxicos. Exigirnos sin cerrar la puerta.
+
+El Skirmish es una invitación a eso.
+
+Nos vemos en CHAOS Hobby Store.

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -671,6 +671,17 @@ main {
     margin: 1.5rem 0;
 }
 
+.blog-post-content iframe {
+    display: block;
+    width: 100%;
+    max-width: 640px;
+    aspect-ratio: 16 / 9;
+    height: auto;
+    margin: 1.5rem auto;
+    border: 0;
+    border-radius: 0.5rem;
+}
+
 .blog-post-content blockquote {
     border-left: 4px solid #91160d;
     padding-left: 1rem;

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1564,6 +1564,33 @@ article ul, article ol {
     color: rgba(255, 255, 255, 0.9);
 }
 
+.event-details {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0.25rem 0 0.5rem;
+    color: rgba(255, 255, 255, 0.88);
+    text-align: center;
+}
+
+.event-details p {
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.45;
+}
+
+.registration-fee {
+    display: inline-block;
+    width: fit-content;
+    padding: 0.2rem 0.6rem;
+    border-radius: 0.25rem;
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
 /* Primary action link - prominent tournament button */
 .action-link--primary {
     background: rgba(255, 215, 0, 0.25) !important;
@@ -1660,6 +1687,10 @@ article ul, article ol {
 .event-ticket--past .event-ticket-content .location {
     font-size: 0.7rem;
     margin-bottom: 0;
+}
+
+.event-ticket--past .event-details {
+    display: none;
 }
 
 .event-ticket--past .actions {

--- a/src/data/Eventos_Comunidad_Q3_2026.json
+++ b/src/data/Eventos_Comunidad_Q3_2026.json
@@ -1,0 +1,14 @@
+[
+  {
+    "Date": "2026-08-08",
+    "Day": "Sábado",
+    "Event": "Skirmish Season 15 - Silver Age",
+    "Time": "10 AM",
+    "Location": "CHAOS Hobby Store",
+    "Ciudad": "Cali",
+    "Emoji": "⚔️",
+    "EventType": "Sage",
+    "RegistrationFee": "$80.000 COP",
+    "Description": "Primera Skirmish oficial en Colombia. Jornada competitiva de Flesh and Blood para jugadores nuevos y experimentados, con estrategia y premios para la comunidad."
+  }
+]

--- a/src/data/Eventos_Comunidad_Q3_2026.json
+++ b/src/data/Eventos_Comunidad_Q3_2026.json
@@ -1,5 +1,205 @@
 [
   {
+    "Date": "2026-07-04",
+    "Day": "Sábado",
+    "Event": "Classic Constructed",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-07-04",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-07",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-07-09",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-11",
+    "Day": "Sábado",
+    "Event": "Classic Constructed",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-07-11",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-14",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-07-16",
+    "Day": "Jueves",
+    "Event": "Classic Constructed",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-07-18",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-18",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-21",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-07-23",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-25",
+    "Day": "Sábado",
+    "Event": "Living Legend",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏆",
+    "EventType": "LL"
+  },
+  {
+    "Date": "2026-07-25",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-07-28",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-07-30",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-01",
+    "Day": "Sábado",
+    "Event": "Classic Constructed",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-08-01",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-04",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-08-06",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
     "Date": "2026-08-08",
     "Day": "Sábado",
     "Event": "Skirmish Season 15 - Silver Age",
@@ -10,5 +210,305 @@
     "EventType": "Sage",
     "RegistrationFee": "$80.000 COP",
     "Description": "Primera Skirmish oficial en Colombia. Jornada competitiva de Flesh and Blood para jugadores nuevos y experimentados, con estrategia y premios para la comunidad."
+  },
+  {
+    "Date": "2026-08-08",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-11",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-08-13",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-15",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-15",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-18",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-08-20",
+    "Day": "Jueves",
+    "Event": "Classic Constructed",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-08-22",
+    "Day": "Sábado",
+    "Event": "Classic Constructed",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-08-22",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-25",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-08-27",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-08-29",
+    "Day": "Sábado",
+    "Event": "Living Legend",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏆",
+    "EventType": "LL"
+  },
+  {
+    "Date": "2026-08-29",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-01",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-09-03",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-05",
+    "Day": "Sábado",
+    "Event": "Classic Constructed",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-09-05",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-08",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-09-10",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-12",
+    "Day": "Sábado",
+    "Event": "Classic Constructed",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-09-12",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-15",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-09-17",
+    "Day": "Jueves",
+    "Event": "Classic Constructed",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏗️",
+    "EventType": "CC"
+  },
+  {
+    "Date": "2026-09-19",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-19",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-22",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
+  },
+  {
+    "Date": "2026-09-24",
+    "Day": "Jueves",
+    "Event": "Silver Age",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-26",
+    "Day": "Sábado",
+    "Event": "Living Legend",
+    "Time": "3 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🏆",
+    "EventType": "LL"
+  },
+  {
+    "Date": "2026-09-26",
+    "Day": "Sábado",
+    "Event": "Silver Age",
+    "Time": "3 PM",
+    "Location": "Palmira",
+    "Ciudad": "Palmira",
+    "Emoji": "🌀",
+    "EventType": "Sage"
+  },
+  {
+    "Date": "2026-09-29",
+    "Day": "Martes",
+    "Event": "Free Play",
+    "Time": "5 PM",
+    "Location": "Chaos Store",
+    "Ciudad": "Cali",
+    "Emoji": "🃏",
+    "EventType": "FreePlay"
   }
 ]

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -8,6 +8,12 @@ import { es } from 'date-fns/locale';
 const posts = (await getCollection('posts')).sort(
   (a, b) => new Date(b.data.publishDate).getTime() - new Date(a.data.publishDate).getTime()
 );
+
+const toDisplayDate = (date: Date) => new Date(
+  date.getUTCFullYear(),
+  date.getUTCMonth(),
+  date.getUTCDate()
+);
 ---
 
 <Layout>
@@ -26,7 +32,7 @@ const posts = (await getCollection('posts')).sort(
     <PageBanner image="/images/home/blog-news.webp" alt="Escritorio editorial con cartas y notas de estrategia" />
     <div class="blog-container">
       {posts.map((post, index) => {
-        const postDate = new Date(post.data.publishDate);
+        const postDate = toDisplayDate(post.data.publishDate);
         const dayNumber = format(postDate, 'd');
         const monthAbbr = format(postDate, 'MMM', { locale: es }).toUpperCase();
         const isEven = index % 2 === 0;

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -17,7 +17,12 @@ const post = await getEntry('posts', slug);
 if (!post) throw new Error(`Post not found: ${slug}`);
 const { Content } = await render(post);
 
-const postDate = new Date(post.data.publishDate);
+const toDisplayDate = (date: Date) => new Date(
+  date.getUTCFullYear(),
+  date.getUTCMonth(),
+  date.getUTCDate()
+);
+const postDate = toDisplayDate(post.data.publishDate);
 const formattedDate = format(postDate, "d 'de' MMMM, yyyy", { locale: es });
 ---
 

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -22,6 +22,8 @@ const allEvents = eventsData
         key: `${e.Date}-${e.Event}-${e.Time}`,
         tournamentUrl: e.TournamentURL,
         tournamentName: e.TournamentName,
+        registrationFee: e.RegistrationFee,
+        description: e.Description,
     }))
     .sort((a, b) => a.dateObj.getTime() - b.dateObj.getTime());
 

--- a/src/utils/dataLoader.js
+++ b/src/utils/dataLoader.js
@@ -1,4 +1,4 @@
-import eventsData from '../data/Eventos_Comunidad_Q2_2026.json';
+import eventsData from '../data/Eventos_Comunidad_Q3_2026.json';
 
 export const loadEventsData = () => {
   return eventsData;

--- a/tools/challonge/create_tournament.py
+++ b/tools/challonge/create_tournament.py
@@ -36,7 +36,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 OAUTH_CONFIG_PATH = os.path.join(SCRIPT_DIR, 'oauth_config.json')
 TEMPLATES_PATH = os.path.join(SCRIPT_DIR, 'templates.json')
 CARDS_PATH = os.path.join(SCRIPT_DIR, 'cards.json')
-CALENDAR_PATH = os.path.join(SCRIPT_DIR, '..', '..', 'src', 'data', 'Eventos_Comunidad_Q2_2026.json')
+CALENDAR_PATH = os.path.join(SCRIPT_DIR, '..', '..', 'src', 'data', 'Eventos_Comunidad_Q3_2026.json')
 
 # API endpoints
 AUTH_URL = 'https://api.challonge.com/oauth/authorize'


### PR DESCRIPTION
## Summary

- Adds the Skirmish 2026 blog post by integrating the existing long-form post with the event details and YouTube video embed.
- Extends the active Q3 2026 calendar with the still-current recurring events and the Skirmish Season 15 special event.
- Updates calendar/blog rendering helpers so event details, calendar links, embedded video, and publish dates render correctly.

## Validation

- yarn build

## Notes

The Skirmish event is scheduled for Saturday, August 8, 2026 at 10:00 AM at CHAOS Hobby Store with a .000 COP registration fee.